### PR TITLE
Initial PR - Add Game Patch Notes link to Descrption

### DIFF
--- a/hun/constants.py
+++ b/hun/constants.py
@@ -106,6 +106,7 @@ NOTICE = {
     Region.ZZZ_CN: "https://bbs.mihoyo.com/zzzToBBS.html",
 }
 
+
 def get_region_name(region: Region) -> str:
     return REGION_NAMES.get(region, "Unknown region")
 
@@ -117,5 +118,6 @@ def get_region_icon(region: Region) -> str:
 
     return ""
 
-def get_notice_url(region: Region) -> str:
-    return NOTICE.get(region, "")
+
+def get_notice_url(region: Region) -> str | None:
+    return NOTICE.get(region)

--- a/hun/webhook.py
+++ b/hun/webhook.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import aiohttp
 
-from .constants import REGION_NAMES, Region, get_region_icon, get_notice_url
+from .constants import REGION_NAMES, Region, get_notice_url, get_region_icon
 
 __all__ = (
     "get_game_maint_webhook_data",
@@ -21,8 +21,8 @@ def get_game_webhook_data(
     description = f"{REGION_NAMES[region]}: v{version}"
 
     # Only add the patch notes link if it's NOT a preload
-    if not is_preload:
-        description += f"\n[Read what's new here!]({get_notice_url(region)})"
+    if not is_preload and (notice_url := get_notice_url(region)):
+        description += f"\n[Read what's new here!]({notice_url})"
 
     return {
         "username": "Hoyo Update Notifier",
@@ -34,9 +34,7 @@ def get_game_webhook_data(
                     "url": "https://hoyo-update-notifier.seria.moe",
                 },
                 "title": (
-                    "A new preload is available!"
-                    if is_preload
-                    else "A new update is available!"
+                    "A new preload is available!" if is_preload else "A new update is available!"
                 ),
                 "description": description,
                 "color": 8688619,
@@ -45,7 +43,6 @@ def get_game_webhook_data(
         ],
         "content": " ".join(f"<@&{role_id}>" for role_id in role_ids),
     }
-
 
 
 def get_game_maint_webhook_data(


### PR DESCRIPTION
This adds the patch note link to the descrption, linking user to the version update post from HoYo directly.

The first commit was made using Discord Components but was scrapped due to restrictions to Webhooks created by user vs webhooks created by the bot with learning what dark magic the team from Discohook use to exploit the webhook system. 

It's a headache but later it was replaced with Inline Links on the text descrption. 

Patch Note Links supported for GI, SR and ZZZ but not HI3rd due to the endpoint exist for China region and not for Global Region